### PR TITLE
[FE #29] PriceFilter Button Component 

### DIFF
--- a/FE/huey/package-lock.json
+++ b/FE/huey/package-lock.json
@@ -11521,6 +11521,11 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.11.tgz",
       "integrity": "sha512-VfPwgcGABbGAue9+sfrD4PuwFar7gPb1yl1UK1MwXoQPAw0BKSqWfoYCT/ThFrdEVWoI51dBuyCoiNU9bZDZxQ=="
     },
+    "vue-class-component": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/vue-class-component/-/vue-class-component-7.2.3.tgz",
+      "integrity": "sha512-oEqYpXKaFN+TaXU+mRLEx8dX0ah85aAJEe61mpdoUrq0Bhe/6sWhyZX1JjMQLhVsHAkncyhedhmCdDVSasUtDw=="
+    },
     "vue-eslint-parser": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.1.0.tgz",
@@ -11579,10 +11584,26 @@
         }
       }
     },
+    "vue-property-decorator": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/vue-property-decorator/-/vue-property-decorator-8.4.2.tgz",
+      "integrity": "sha512-IqbARlvgPE2pzKfbecKxsu2yEH0Wv7hfHR6m4eZA3LTnNw9hveAX77vDfLFyTeMISS5N7Kucp/xRSHjcQ6bAfQ==",
+      "requires": {
+        "vue-class-component": "^7.1.0"
+      }
+    },
     "vue-router": {
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.1.6.tgz",
       "integrity": "sha512-GYhn2ynaZlysZMkFE5oCHRUTqE8BWs/a9YbKpNLi0i7xD6KG1EzDqpHQmv1F5gXjr8kL5iIVS8EOtRaVUEXTqA=="
+    },
+    "vue-slider-component": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/vue-slider-component/-/vue-slider-component-3.1.3.tgz",
+      "integrity": "sha512-SPFb1I3G2a4thIwghvVNhcvPGCUz6PIZR1ClwtvN4MT44ZUzvqCMDS7osdKz0hdKu4kfanxET8qZn826A/XPxA==",
+      "requires": {
+        "vue-property-decorator": "^8.0.0"
+      }
     },
     "vue-style-loader": {
       "version": "4.1.2",
@@ -11617,6 +11638,11 @@
       "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz",
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
+    },
+    "vuetrend": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/vuetrend/-/vuetrend-0.3.4.tgz",
+      "integrity": "sha512-UaOJhMnkoiRBlGB9k2FX5GqotJyoyYUpyTAjfBiB7K5ESt3KzRoaplfG7j7SAnH4ITk4DjVDC9WB2IX80TVYmQ=="
     },
     "watchpack": {
       "version": "1.7.2",

--- a/FE/huey/package.json
+++ b/FE/huey/package.json
@@ -14,7 +14,9 @@
     "date-fns": "^2.14.0",
     "v-click-outside": "^3.0.1",
     "vue": "^2.6.11",
-    "vue-router": "^3.1.6"
+    "vue-router": "^3.1.6",
+    "vue-slider-component": "^3.1.3",
+    "vuetrend": "^0.3.4"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "~4.3.0",

--- a/FE/huey/src/components/AirbnbStyleChartCount.vue
+++ b/FE/huey/src/components/AirbnbStyleChartCount.vue
@@ -1,0 +1,57 @@
+<template>
+  <div>
+    <trend
+      :data="[
+        0,
+        2,
+        5,
+        9,
+        5,
+        10,
+        3,
+        5,
+        0,
+        3,
+        5,
+        0,
+        0,
+        1,
+        8,
+        2,
+        9,
+        0,
+        5,
+        0,
+        0,
+        1,
+        8,
+        2,
+        9,
+        0,
+        0,
+        2,
+        10,
+        3,
+        5,
+        0,
+        0,
+        1,
+        8,
+        2,
+        9,
+        0,
+      ]"
+      :gradient="['#6fa8dc', '#42b983', '#2c3e50']"
+      auto-draw
+      smooth
+      autoDrawEasing="linear"
+    >
+    </trend>
+  </div>
+</template>
+
+<script>
+export default {};
+</script>
+
+<style></style>

--- a/FE/huey/src/components/AirbnbStylePriceCount.vue
+++ b/FE/huey/src/components/AirbnbStylePriceCount.vue
@@ -1,0 +1,83 @@
+<template>
+  <div>
+    <vue-slider
+      ref="slider"
+      v-model="value"
+      v-bind="options"
+      @drag-end="changePrice"
+    ></vue-slider>
+    <div class="price-detail-wrap">
+      <span>{{ this.value[0] }}</span>
+      <span>{{ this.value[1] }}</span>
+    </div>
+  </div>
+</template>
+
+<script>
+import VueSlider from 'vue-slider-component';
+import 'vue-slider-component/theme/default.css';
+
+export default {
+  data() {
+    return {
+      value: [312000, 1000000],
+      options: {
+        dotSize: 14,
+        width: 'auto',
+        height: 4,
+        contained: false,
+        direction: 'ltr',
+        data: null,
+        min: 0,
+        max: 1200000,
+        interval: 1,
+        disabled: false,
+        clickable: true,
+        duration: 0.5,
+        adsorb: false,
+        lazy: false,
+        tooltip: 'active',
+        tooltipPlacement: 'top',
+        tooltipFormatter: void 0,
+        useKeyboard: false,
+        keydownHook: null,
+        dragOnClick: false,
+        enableCross: false,
+        fixed: false,
+        minRange: void 0,
+        maxRange: void 0,
+        order: true,
+        marks: false,
+        dotOptions: void 0,
+        process: true,
+        dotStyle: void 0,
+        railStyle: void 0,
+        processStyle: void 0,
+        tooltipStyle: void 0,
+        stepStyle: void 0,
+        stepActiveStyle: void 0,
+        labelStyle: void 0,
+        labelActiveStyle: void 0,
+      },
+    };
+  },
+  components: {
+    VueSlider,
+  },
+  methods: {
+    changePrice(e) {
+      this.$emit('chageValue', {
+        minValue: this.value[0],
+        maxValue: this.value[1],
+      });
+    },
+  },
+};
+</script>
+
+<style>
+.price-detail-wrap {
+  display: flex;
+  justify-content: space-around;
+}
+</style>

--- a/FE/huey/src/components/PersonFilterButtonComponent.vue
+++ b/FE/huey/src/components/PersonFilterButtonComponent.vue
@@ -1,8 +1,10 @@
 <template>
   <div>
-    <b-button v-b-modal.my-modal>{{
-      personData(adultConut, childrenCount, babyCount) || '인원 / 게스트 추가'
-    }}</b-button>
+    <b-button v-b-modal.my-modal>
+      {{
+        personData(adultConut, childrenCount, babyCount) || '인원 / 게스트 추가'
+      }}</b-button
+    >
     <b-modal id="my-modal">
       <div class="adult-wrap wrap">
         <div class="adult-title title">

--- a/FE/huey/src/components/PriceFilterButtonComponent.vue
+++ b/FE/huey/src/components/PriceFilterButtonComponent.vue
@@ -1,0 +1,43 @@
+<template>
+  <div>
+    <b-button v-b-modal.my-price>
+      {{ priceData(minPrice, maxPrice) || '요급' }}
+    </b-button>
+    <b-modal id="my-price">
+      <div>
+        <span> 평균 가격 : 100,000</span>
+      </div>
+      <AirbnbStyleChartCount />
+      <AirbnbStylePriceCount @chageValue="test" />
+    </b-modal>
+  </div>
+</template>
+
+<script>
+import AirbnbStyleChartCount from '@/components/AirbnbStyleChartCount';
+import AirbnbStylePriceCount from '@/components/AirbnbStylePriceCount';
+
+export default {
+  data() {
+    return {
+      minPrice: 0,
+      maxPrice: 12000,
+    };
+  },
+  components: {
+    AirbnbStyleChartCount,
+    AirbnbStylePriceCount,
+  },
+  methods: {
+    priceData(minPrice, maxPrice) {
+      return `₩${this.minPrice} ~ ₩${this.maxPrice}`;
+    },
+    test(e) {
+      this.minPrice = e.minValue;
+      this.maxPrice = e.maxValue;
+    },
+  },
+};
+</script>
+
+<style></style>

--- a/FE/huey/src/main.js
+++ b/FE/huey/src/main.js
@@ -3,9 +3,11 @@ import App from './App.vue';
 import router from '@/routes/index';
 import AirBnbStyleDatepicker from '@/utils/index';
 import { BootstrapVue, IconsPlugin } from 'bootstrap-vue';
+import Trend from 'vuetrend';
 
 Vue.config.productionTip = false;
 
+Vue.use(Trend);
 Vue.use(BootstrapVue);
 Vue.use(IconsPlugin);
 Vue.use(AirBnbStyleDatepicker, {

--- a/FE/huey/src/views/MainView.vue
+++ b/FE/huey/src/views/MainView.vue
@@ -2,17 +2,22 @@
   <div class="filter-wrap">
     <date-filter-button-component></date-filter-button-component>
     <person-filter-button-component></person-filter-button-component>
+    <price-filter-button-component
+      class="range-slider-container"
+    ></price-filter-button-component>
   </div>
 </template>
 
 <script>
 import DateFilterButtonComponent from '@/components/DateFilterButtonComponent';
 import PersonFilterButtonComponent from '@/components/PersonFilterButtonComponent';
+import PriceFilterButtonComponent from '@/components/PriceFilterButtonComponent';
 
 export default {
   components: {
     DateFilterButtonComponent,
     PersonFilterButtonComponent,
+    PriceFilterButtonComponent,
   },
 };
 </script>
@@ -21,6 +26,10 @@ export default {
 .filter-wrap {
   display: flex;
   justify-content: space-around;
-  width: 400px;
+  width: 600px;
+}
+
+.range-slider-container {
+  width: 200px;
 }
 </style>


### PR DESCRIPTION
### PriceFilter Button Component
![스크린샷 2020-05-21 오후 3 30 35](https://user-images.githubusercontent.com/48382080/82530340-07f37d00-9b78-11ea-8a3b-81d1e29a6a3d.png)

- [X] 현재 날짜를 기준으로 선택한 숙소들 가격 범위를 표시하는 화면이다. 최저가부터 최고가 사이 가격 범위를 표시한다. 단, 최고가 100만원 이상 되는 경우는 “100만원 이상”으로 표시한다.
그 아래에는 선택한 숙소들 평균 가격을 표시한다.

- [X] 가격 범위에 따라 그래프를 표시한다. x축은 최저-최고 가격 범위이고, y축은 숙소 개수를 의미한다.

- [X] 3-1. 사용자는 range slider를 이용해 가격을 설정할 수 있다.
3-2. 슬라이더의 버튼이 양 끝에 있고, 가격 입력 박스에 최저/최고값이 표시된 상태가 디폴트이다.
3-3. 사용자는 슬라이더의 버튼을 drag&drop을 해서 가격 범위 설정을 할 수 있다.
3-4. 설정한 범위 내의 라인(버튼과 버튼 사이 부분)은 키컬러로, 범위 밖의 라인은 회색으로 표현된다.
3-5. 두 개의 버튼은 서로 완전히 겹치거나 서로를 지나쳐서 이동될 수 없다. 즉, 왼쪽 버튼은 늘 최저 가격, 오른쪽 버튼은 늘 최고 가격을 표현한다.

- [X] 지우기 버튼을 누르면 가격 범위를 선택하지 않은 상태로 돌아간다. 

- [X] 저장버튼을 누르면, 모달창은 닫히고, 해당 범위 숙소만 필터링해서 표시된다.

