### PR TITLE
[FE #40] OAuth 토큰값 인증을 위한 Axios Interceptors

### DIFF
--- a/FE/huey/src/api/common/interceptors.js
+++ b/FE/huey/src/api/common/interceptors.js
@@ -1,0 +1,23 @@
+import store from '@/store/index';
+
+export function setInterceptors(instance) {
+  instance.interceptors.request.use(
+    function (config) {
+      config.headers.Authorization = store.state.token;
+      return config;
+    },
+    function (error) {
+      return Promise.reject(error);
+    },
+  );
+
+  instance.interceptors.response.use(
+    function (response) {
+      return response;
+    },
+    function (error) {
+      return Promise.reject(error);
+    },
+  );
+  return instance;
+}

--- a/FE/huey/src/api/index.js
+++ b/FE/huey/src/api/index.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+import { setInterceptors } from './common/interceptors';
+
+function createInstance() {
+  return axios.create({
+    baseURL: process.env.VUE_APP_API_URL,
+  });
+}
+
+// 액시오스 초기화 함수
+function createInstanceWithAuth(url) {
+  const instance = axios.create({
+    baseURL: `${process.env.VUE_APP_API_URL}${url}`,
+  });
+  return setInterceptors(instance);
+}
+
+export const instance = createInstance();
+export const filter = createInstanceWithAuth('filter');

--- a/FE/huey/src/api/reservation.js
+++ b/FE/huey/src/api/reservation.js
@@ -1,0 +1,8 @@
+import { filter } from './index';
+
+// API를 추가할 예정
+function fetchPosts() {
+  return filter.get('/');
+}
+
+export { fetchPosts };


### PR DESCRIPTION
### Axios Interceptors

- env에 Base api 요청 주소를 입력해둔다
- Oauth가 실행되면 store에 state에 토큰값을 저장해둔다
- 모든 API 요청을 하기전에 config.headers에 authorization 키값으로 토큰값을 주입해준다
- 토큰값이 없다면 로그인 페이지로 리다이렉트 시켜주어야 한다
- 로그인 관련 API를 인스턴스를 뺴서 하나 만들어둔다